### PR TITLE
LineCollection: Fix unpack limit being hit for large inserts

### DIFF
--- a/src/LineCollection.moon
+++ b/src/LineCollection.moon
@@ -226,9 +226,12 @@ class LineCollection
 			line.inserted = true
 			@lastLineNumber = math.max @lastLineNumber, line.number
 
-		unless #tailLines == 0
-			@sub.insert @lastLineNumber + 1, unpack tailLines
-			@lastLineNumber = math.max @lastLineNumber, tailLines[#tailLines].number
+		tailLineCnt, chunkSize = #tailLines, 1000
+		if tailLineCnt > 0
+			for i = 1, tailLineCnt, chunkSize
+				chunkSize = math.min chunkSize, tailLineCnt - i + 1
+				@sub.insert @lastLineNumber + i, unpack tailLines, i, i+chunkSize-1
+			@lastLineNumber = math.max @lastLineNumber, tailLines[tailLineCnt].number
 
 	replaceLines: =>
 		if @shouldInsertLines


### PR DESCRIPTION
Trying to insert a large amount of lines at the end of an ASS script at once causes the maximum number of table items unpacked to arguments to be exceeded.
This PR rectifies that issue by processing large inserts in chunks of at most 1000 lines. This is lower than the limit of 8000 items imposed by LuaJIT, but still fast enough to make it worthwhile to stay on the safe side wrt/ stack size. 